### PR TITLE
Updating Prepare to Dye Plus to 1.3.16

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -7623,7 +7623,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "3275682af759449160e0ce0c3b68682112414f4aafe014efffb5c356c4c387e0"
+hash = "6f4cbfaa0e7f282daf4e41663165fd1a6f3bb8d94be7b4dc276eb6684bb7ded4"
 metafile = true
 
 [[files]]

--- a/mods/ptdye-plus.pw.toml
+++ b/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.3.7+forge-1.19.2.jar"
+filename = "ptdyeplus-1.3.16+forge-1.19.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/uyzG4Y6H/ptdyeplus-1.3.7%2Bforge-1.19.2.jar"
+url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/9TqnWvkh/ptdyeplus-1.3.16%2Bforge-1.19.2.jar"
 hash-format = "sha1"
-hash = "16448e04649845d7c3634de0e4af8434480abc09"
+hash = "cbe044cde14739447e6c9887565a7f5b4abb00a7"
 
 [update]
 [update.modrinth]
 mod-id = "ikDjkgLu"
-version = "uyzG4Y6H"
+version = "9TqnWvkh"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "c34ae4fc5c1705fabb8ad6254d706f4d6c1ef1a89d9e4c0ecf5b692cc0f4e5ff"
+hash = "aa480a3858a0c27be51f1b12b24db13e4c9c99bd1146f6d351927870faaa2bb7"
 
 [versions]
 forge = "43.3.2"


### PR DESCRIPTION
Changelog: ### [1.3.16](https://github.com/jasperalani/ptdye-plus/compare/1.3.15...1.3.16) (2024-01-15)