### PR TITLE
Updating Prepare to Dye Plus to 1.3.10

### DIFF
--- a/curseforge/index.toml
+++ b/curseforge/index.toml
@@ -282,7 +282,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "612ec1fb99ce6d17735a2e4d51fdc76e91cf3a26d49ded6c3f65c7f1cc005ba4"
+hash = "9967fe18b421fe95992e0c210484b4320fa18f0527ccd6a77a04116fc274b394"
 metafile = true
 
 [[files]]

--- a/curseforge/mods/ptdye-plus.pw.toml
+++ b/curseforge/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.3.7+forge-1.19.2.jar"
+filename = "ptdyeplus-1.3.10+forge-1.19.2.jar"
 side = "client"
 
 [download]
 hash-format = "sha1"
-hash = "51b592688e178b59b1838ac8dbaa8248"
+hash = "cbdbaf1859437c146f9b0de441dd9c6c1aeb06fa"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5019109
+file-id = 5034976
 project-id = 952113

--- a/curseforge/pack.toml
+++ b/curseforge/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "69663e5a198ce5f5016206c92ef4b6877bcce3c83f457df8fa5c1a2ddc509173"
+hash = "a63b9d83545be75cc866aa8ad14748afd57320cc184fde5d9eecff3caf6ed253"
 
 [versions]
 forge = "43.3.5"

--- a/index.toml
+++ b/index.toml
@@ -7631,7 +7631,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "3275682af759449160e0ce0c3b68682112414f4aafe014efffb5c356c4c387e0"
+hash = "c2487db7665a0ce9a77115cb89a2ba24d14c268751d8e2c1513d23563c50a717"
 metafile = true
 
 [[files]]

--- a/mods/ptdye-plus.pw.toml
+++ b/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.3.7+forge-1.19.2.jar"
+filename = "ptdyeplus-1.3.10+forge-1.19.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/uyzG4Y6H/ptdyeplus-1.3.7%2Bforge-1.19.2.jar"
+url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/ufxeXAW1/ptdyeplus-1.3.10%2Bforge-1.19.2.jar"
 hash-format = "sha1"
-hash = "16448e04649845d7c3634de0e4af8434480abc09"
+hash = "6915731d47f7b39f45db06d4ef65a364f42161f0"
 
 [update]
 [update.modrinth]
 mod-id = "ikDjkgLu"
-version = "uyzG4Y6H"
+version = "ufxeXAW1"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "14cfc9842332c242ef4e6745b775ea439a806d176ed309a5d99aa357bcb3e960"
+hash = "65d23303fcad3948e08db59cb15c51f29af6867f61fa2831d1a94e3e557d9777"
 
 [versions]
 forge = "43.3.2"


### PR DESCRIPTION
Changelog: ### [1.3.10](https://github.com/jasperalani/ptdye-plus/compare/1.3.7...1.3.10) (2024-01-15)
