### PR TITLE
Updating Prepare to Dye Plus to 1.3.11

### DIFF
--- a/curseforge/index.toml
+++ b/curseforge/index.toml
@@ -282,7 +282,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "9967fe18b421fe95992e0c210484b4320fa18f0527ccd6a77a04116fc274b394"
+hash = "08807993c2e4f9771d037d9e6726cfbfa3d9c37c4a70de4713a037260e07e159"
 metafile = true
 
 [[files]]

--- a/curseforge/mods/ptdye-plus.pw.toml
+++ b/curseforge/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.3.10+forge-1.19.2.jar"
+filename = "ptdyeplus-1.3.11+forge-1.19.2.jar"
 side = "client"
 
 [download]
 hash-format = "sha1"
-hash = "cbdbaf1859437c146f9b0de441dd9c6c1aeb06fa"
+hash = "8821bd8ec858fb7fa8c50f966f2cda169065dfc7"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5034976
+file-id = 5041323
 project-id = 952113

--- a/curseforge/pack.toml
+++ b/curseforge/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "a63b9d83545be75cc866aa8ad14748afd57320cc184fde5d9eecff3caf6ed253"
+hash = "fcf08fd7fdec51709f4b99544fb58eba36a6eb8e9e1d99bb9d6f1243a4df0e43"
 
 [versions]
 forge = "43.3.5"

--- a/index.toml
+++ b/index.toml
@@ -7635,7 +7635,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "c2487db7665a0ce9a77115cb89a2ba24d14c268751d8e2c1513d23563c50a717"
+hash = "87a85bc86d96d49f7cb2502172649980074c4cdef5be1a57e7bf1f29f87cebda"
 metafile = true
 
 [[files]]

--- a/mods/ptdye-plus.pw.toml
+++ b/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.3.10+forge-1.19.2.jar"
+filename = "ptdyeplus-1.3.11+forge-1.19.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/ufxeXAW1/ptdyeplus-1.3.10%2Bforge-1.19.2.jar"
+url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/P6H8w5Ul/ptdyeplus-1.3.11%2Bforge-1.19.2.jar"
 hash-format = "sha1"
-hash = "6915731d47f7b39f45db06d4ef65a364f42161f0"
+hash = "1cad6540857bebcff66668d01b57bae827427279"
 
 [update]
 [update.modrinth]
 mod-id = "ikDjkgLu"
-version = "ufxeXAW1"
+version = "P6H8w5Ul"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "3b325112144f499f028a22005f95d5fdf49f40ead25dc84bc82d3c6d9c23866b"
+hash = "eeb988ff22018e9fabb805d25944c7efded3035d879ee0add2c63b4feb593ffc"
 
 [versions]
 forge = "43.3.2"


### PR DESCRIPTION
Changelog: ### [1.3.11](https://github.com/jasperalani/ptdye-plus/compare/1.3.10...1.3.11) (2024-01-17)

### Developer experience improvments and changes

* new step so the echo shows before sleeping ([e8b0544](https://github.com/jasperalani/ptdye-plus/commit/e8b0544388c696e0ce0fa268b507ea9f57247438))

### Other
* Adds extended reach on some blocks: https://github.com/jasperalani/ptdye-plus/pull/6