### PR TITLE
Updating Prepare to Dye Plus to 1.3.12

### DIFF
--- a/curseforge/index.toml
+++ b/curseforge/index.toml
@@ -282,7 +282,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "08807993c2e4f9771d037d9e6726cfbfa3d9c37c4a70de4713a037260e07e159"
+hash = "44b0e24e3d346613908c6304f38d7a64e6df3042f17669db989253d97629a1e3"
 metafile = true
 
 [[files]]

--- a/curseforge/mods/ptdye-plus.pw.toml
+++ b/curseforge/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.3.11+forge-1.19.2.jar"
+filename = "ptdyeplus-1.3.12+forge-1.19.2.jar"
 side = "client"
 
 [download]
 hash-format = "sha1"
-hash = "8821bd8ec858fb7fa8c50f966f2cda169065dfc7"
+hash = "7de9d318a403f50b40a298a8fa0984028c31f10c"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5041323
+file-id = 5055090
 project-id = 952113

--- a/curseforge/pack.toml
+++ b/curseforge/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "bb015481c94a3f1ff19cb95d2fb9d3b37c686bc28a3db2f27b4055e831c09325"
+hash = "83cb6728ec73f0b1d59cd95520a845d6eea13b8e2f44109172c17cc9f00faedd"
 
 [versions]
 forge = "43.3.5"

--- a/index.toml
+++ b/index.toml
@@ -7775,7 +7775,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "87a85bc86d96d49f7cb2502172649980074c4cdef5be1a57e7bf1f29f87cebda"
+hash = "b8200fb2516dac5488122b0a50afd814255000b350d33ada7055a2ce60a983fd"
 metafile = true
 
 [[files]]

--- a/mods/ptdye-plus.pw.toml
+++ b/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.3.11+forge-1.19.2.jar"
+filename = "ptdyeplus-1.3.12+forge-1.19.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/P6H8w5Ul/ptdyeplus-1.3.11%2Bforge-1.19.2.jar"
+url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/yYIT8xN2/ptdyeplus-1.3.12%2Bforge-1.19.2.jar"
 hash-format = "sha1"
-hash = "1cad6540857bebcff66668d01b57bae827427279"
+hash = "d8ce87d474a263a922fc0f9b0b36dd2538e73400"
 
 [update]
 [update.modrinth]
 mod-id = "ikDjkgLu"
-version = "P6H8w5Ul"
+version = "yYIT8xN2"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "df3bca7ce9abd7aa8e081961f1638892441b0e3ff09168b7e8bf45a81a073201"
+hash = "14516f9bce3a089d4ea2f30ef15710bc686a35f85f02395e90543af928f97353"
 
 [versions]
 forge = "43.3.2"


### PR DESCRIPTION
Changelog: ### [1.3.12](https://github.com/game-design-driven/ptdye-plus/compare/1.3.11...1.3.12) (2024-01-23)


### Minor tweaks

* reorganise files ([7677835](https://github.com/game-design-driven/ptdye-plus/commit/7677835de204957eb11fa928493b7e4892498783))


### Fixes

* server crash when open trading terminal on multiplayer ([8c74ae6](https://github.com/game-design-driven/ptdye-plus/commit/8c74ae6a73efddd948a81b71ee7cc25b0cfa39a9))