### PR TITLE
Fix: Movable bedrock

### DIFF
--- a/kubejs/config/probejs.json
+++ b/kubejs/config/probejs.json
@@ -1,7 +1,7 @@
 {
   "firstLoad": false,
   "noAggressiveProbing": true,
-  "docsTimestamp": 1694524116376,
+  "docsTimestamp": 1704370339573,
   "allowRegistryObjectDumps": false,
   "requireSingleAndPerm": true,
   "enabled": true,

--- a/kubejs/server_scripts/base/featrues/immovable.js
+++ b/kubejs/server_scripts/base/featrues/immovable.js
@@ -1,0 +1,13 @@
+// For some reason, some blocks that aren't meant to be movable by create are.
+// This is a work around to stop them from being moved by create.
+
+addToTag("forge:relocation_not_supported", [
+  "minecraft:bedrock",
+  "minecraft:command_block",
+  "minecraft:end_portal_frame",
+  "minecraft:spawner",
+  "minecraft:budding_amethyst",
+  "minecraft:jigsaw",
+  "minecraft:structure_block",
+  "minecraft:structure_void",
+])


### PR DESCRIPTION
This PR addresses #518 and other blocks found movable when they should not be when comparing them to the [create wiki](https://create.fandom.com/wiki/Contraption#Unmovable_Blocks).