### PR TITLE
Updating Prepare to Dye Plus to 1.5.3

### DIFF
--- a/curseforge/index.toml
+++ b/curseforge/index.toml
@@ -282,7 +282,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "05f4e8432fc148db52745c12b07330df6bf4c878b727c62e5c27b63c0362919a"
+hash = "46a100e81eea71ed3e2585b7182b1788ce86063d7d205fa6c3f09546c62d9712"
 metafile = true
 
 [[files]]

--- a/curseforge/mods/ptdye-plus.pw.toml
+++ b/curseforge/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.5.2+forge-1.19.2.jar"
+filename = "ptdyeplus-1.5.3+forge-1.19.2.jar"
 side = "client"
 
 [download]
 hash-format = "sha1"
-hash = "60910a67abd189c1144b63be40149cd6375f3489"
+hash = "0e9da940f1f24f79fe0639710aae6e954499de4f"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5067783
+file-id = 5069848
 project-id = 952113

--- a/curseforge/pack.toml
+++ b/curseforge/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "af51441172807337a0b80d2c1296280da8e5bdff8bfe80af2e899231e38093fe"
+hash = "09e76deda8e51fe0dc09a5cd40bd3604dd223b381e23c2124a82bea191218969"
 
 [versions]
 forge = "43.3.5"

--- a/index.toml
+++ b/index.toml
@@ -7951,7 +7951,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "7a81b99a095d73c42ceecbeb71887bd81a0d94a79ec51424bbefa27508e60561"
+hash = "1ce453c03aca87a1a8490249d89c5037679d5a1ab80ccc61336f3f0c77a7c0bc"
 metafile = true
 
 [[files]]

--- a/mods/ptdye-plus.pw.toml
+++ b/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.5.2+forge-1.19.2.jar"
+filename = "ptdyeplus-1.5.3+forge-1.19.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/Or6SPFNT/ptdyeplus-1.5.2%2Bforge-1.19.2.jar"
+url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/Gidb0yZ2/ptdyeplus-1.5.3%2Bforge-1.19.2.jar"
 hash-format = "sha1"
-hash = "d015da7885381b852f60dd2c5d72e319410e57dd"
+hash = "8425394f577b62714a703d49eb067f1e180d69ad"
 
 [update]
 [update.modrinth]
 mod-id = "ikDjkgLu"
-version = "Or6SPFNT"
+version = "Gidb0yZ2"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "24fcd916b68053751d8d9bc4f9102c7c5b46a51e349aa3a25f73367bd64658de"
+hash = "c967938543e86397fb27704dee8b0ac5e84a2075712dab3ee8257437ba6c0b73"
 
 [versions]
 forge = "43.3.2"


### PR DESCRIPTION
Changelog: ### [1.5.3](https://github.com/game-design-driven/ptdye-plus/compare/1.5.2...1.5.3) (2024-01-30)


### Fixes

* barrels and crates now drop their respective item ([c9665ed](https://github.com/game-design-driven/ptdye-plus/commit/c9665edbc5402b7725763681902326b16602e623))