### PR TITLE
Updating Prepare to Dye Plus to 1.5.4

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -7955,7 +7955,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "1ce453c03aca87a1a8490249d89c5037679d5a1ab80ccc61336f3f0c77a7c0bc"
+hash = "23f6049e2500d45c248c638cb709f5c8fb72e7d04d1bdc1776c67f3d21f4edae"
 metafile = true
 
 [[files]]

--- a/mods/ptdye-plus.pw.toml
+++ b/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.5.3+forge-1.19.2.jar"
+filename = "ptdyeplus-1.5.4+forge-1.19.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/Gidb0yZ2/ptdyeplus-1.5.3%2Bforge-1.19.2.jar"
+url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/ti97Ldra/ptdyeplus-1.5.4%2Bforge-1.19.2.jar"
 hash-format = "sha1"
-hash = "8425394f577b62714a703d49eb067f1e180d69ad"
+hash = "9864fb2350c0d1e78bf4e53fb719e48de940a6b2"
 
 [update]
 [update.modrinth]
 mod-id = "ikDjkgLu"
-version = "Gidb0yZ2"
+version = "ti97Ldra"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "04f5cee63ea38e36bfb6e807193fb1226a5f6945038c4e212976b60da261032b"
+hash = "9b7782daa8c0ea8e556898601c37226185ec0f5974ec4a62d858dccb059fb6d5"
 
 [versions]
 forge = "43.3.2"


### PR DESCRIPTION
Changelog: ### [1.5.4](https://github.com/game-design-driven/ptdye-plus/compare/1.5.3...1.5.4) (2024-01-31)


### Fixes

* Culled face on crate ([6047f58](https://github.com/game-design-driven/ptdye-plus/commit/6047f58d05bb903c4e6443db73d1459f98fee039))