### PR TITLE
Tweak: Added shadow to discord button

### DIFF
--- a/config/fancymenu/customization/4.txt
+++ b/config/fancymenu/customization/4.txt
@@ -156,6 +156,17 @@ customization {
 }
 
 customization {
+  path = discord-mark-shadow.png
+  orientation = top-left
+  x = 11
+  width = 26
+  action = addtexture
+  actionid = 211a151c-b2a9-4c68-9ac0-2b3fb67050611706717205608
+  y = 316
+  height = 18
+}
+
+customization {
   orientation = top-left
   hidden = true
   x = 106

--- a/config/fancymenu/customization/4.txt
+++ b/config/fancymenu/customization/4.txt
@@ -156,17 +156,6 @@ customization {
 }
 
 customization {
-  path = discord-mark-shadow.png
-  orientation = top-left
-  x = 11
-  width = 26
-  action = addtexture
-  actionid = 211a151c-b2a9-4c68-9ac0-2b3fb67050611706717205608
-  y = 316
-  height = 18
-}
-
-customization {
   orientation = top-left
   hidden = true
   x = 106
@@ -232,6 +221,17 @@ customization {
   actionid = fe2a3f57-5931-4a5c-85ca-1207e0cc8f851699022868288
   y = 0
   height = 30
+}
+
+customization {
+  path = discord-mark-shadow.png
+  orientation = bottom-left
+  x = 11
+  width = 26
+  action = addtexture
+  actionid = 211a151c-b2a9-4c68-9ac0-2b3fb67050611706717205608
+  y = -27
+  height = 18
 }
 
 customization {


### PR DESCRIPTION
Added shadow to the discord button #410 

The shadow is a separate image element. Which makes it easily editable, and didn't require tweaking the original icons. (Shadow image assets was pushed in another PR)

Normal State
![image](https://github.com/game-design-driven/Create-Prepare-to-Dye/assets/56016593/e40a36ec-dcd2-4fd1-aa67-b797d1331892)
Hover State
![image](https://github.com/game-design-driven/Create-Prepare-to-Dye/assets/56016593/add421bf-4406-43ae-842f-b4c940497b63)
