### PR TITLE
Updating Prepare to Dye Plus to 1.5.5

### DIFF
--- a/curseforge/index.toml
+++ b/curseforge/index.toml
@@ -282,7 +282,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "46a100e81eea71ed3e2585b7182b1788ce86063d7d205fa6c3f09546c62d9712"
+hash = "9aed687bafeafbf4039e7f2915df8df4a1bec9941ab8c42bf0070f2db0a79f78"
 metafile = true
 
 [[files]]

--- a/curseforge/mods/ptdye-plus.pw.toml
+++ b/curseforge/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.5.3+forge-1.19.2.jar"
+filename = "ptdyeplus-1.5.5+forge-1.19.2.jar"
 side = "client"
 
 [download]
 hash-format = "sha1"
-hash = "0e9da940f1f24f79fe0639710aae6e954499de4f"
+hash = "90e03fd5161a4d12a5a27875ee96b03dba8053eb"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5069848
+file-id = 5071961
 project-id = 952113

--- a/curseforge/pack.toml
+++ b/curseforge/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "09e76deda8e51fe0dc09a5cd40bd3604dd223b381e23c2124a82bea191218969"
+hash = "83bb334a0c20fd994b16ba836c3b7f997d765b40782cd34f4b3edf4448e349ad"
 
 [versions]
 forge = "43.3.5"

--- a/index.toml
+++ b/index.toml
@@ -7959,7 +7959,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "23f6049e2500d45c248c638cb709f5c8fb72e7d04d1bdc1776c67f3d21f4edae"
+hash = "2639d66b13c9334e93eb22da216f67b3d98ab188a1fb4f8da3d33002e491912e"
 metafile = true
 
 [[files]]

--- a/mods/ptdye-plus.pw.toml
+++ b/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.5.4+forge-1.19.2.jar"
+filename = "ptdyeplus-1.5.5+forge-1.19.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/ti97Ldra/ptdyeplus-1.5.4%2Bforge-1.19.2.jar"
+url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/l44RGh2A/ptdyeplus-1.5.5%2Bforge-1.19.2.jar"
 hash-format = "sha1"
-hash = "9864fb2350c0d1e78bf4e53fb719e48de940a6b2"
+hash = "bd1637ead31d6844433cc5a370227b2296757a18"
 
 [update]
 [update.modrinth]
 mod-id = "ikDjkgLu"
-version = "ti97Ldra"
+version = "l44RGh2A"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "4321cb2ffcb7df50f53922d1d81511314675390427ad115bde3de8c691552863"
+hash = "1fc731786e6061ec11e8a5deb5aee46c2c0b8c1a54f61653e6ef3ee9e5f5690e"
 
 [versions]
 forge = "43.3.2"


### PR DESCRIPTION
Changelog: ### [1.5.5](https://github.com/game-design-driven/ptdye-plus/compare/1.5.4...1.5.5) (2024-01-31)


### Fixes

* fixes server crash from loading client only libraries ([b6f57cf](https://github.com/game-design-driven/ptdye-plus/commit/b6f57cff756721bfa8d6120305cb708b3796983c))