### PR TITLE
Updating Prepare to Dye Plus to 1.5.6

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -7963,7 +7963,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "2639d66b13c9334e93eb22da216f67b3d98ab188a1fb4f8da3d33002e491912e"
+hash = "4b618ec029507932395343f2fefbf6bcaa5856a217606b04b2de594ed6ac1895"
 metafile = true
 
 [[files]]

--- a/mods/ptdye-plus.pw.toml
+++ b/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.5.5+forge-1.19.2.jar"
+filename = "ptdyeplus-1.5.6+forge-1.19.2.jar"
 side = "client"
 
 [download]
-url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/l44RGh2A/ptdyeplus-1.5.5%2Bforge-1.19.2.jar"
+url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/P6ripHDK/ptdyeplus-1.5.6%2Bforge-1.19.2.jar"
 hash-format = "sha1"
-hash = "bd1637ead31d6844433cc5a370227b2296757a18"
+hash = "6676a5f5c554cd3241a93546695d090575ca67f0"
 
 [update]
 [update.modrinth]
 mod-id = "ikDjkgLu"
-version = "l44RGh2A"
+version = "P6ripHDK"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "ba1c09509bac71792d61e9c0c07276bee558cce0f4cf6fda160b19b0c7db70d7"
+hash = "401668352b6044c48ff139c2667a4107dfdd726d616163950140f84a5a1843a3"
 
 [versions]
 forge = "43.3.2"


### PR DESCRIPTION
Changelog: ### [1.5.6](https://github.com/game-design-driven/ptdye-plus/compare/1.5.5...1.5.6) (2024-01-31)


### Fixes

* Server not loading mod constructor ([8d226f6](https://github.com/game-design-driven/ptdye-plus/commit/8d226f6370bf025a772d52ce037dd8639822a33a)), closes [#17](https://github.com/game-design-driven/ptdye-plus/issues/17)