### PR TITLE
Updating Prepare to Dye Plus to 1.5.7

### DIFF
--- a/curseforge/index.toml
+++ b/curseforge/index.toml
@@ -287,7 +287,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "9aed687bafeafbf4039e7f2915df8df4a1bec9941ab8c42bf0070f2db0a79f78"
+hash = "6dbb7dc92b077e6ed9498335a09067206be3f0f11f6405a3af557d95fb1c8526"
 metafile = true
 
 [[files]]

--- a/curseforge/mods/ptdye-plus.pw.toml
+++ b/curseforge/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.5.5+forge-1.19.2.jar"
+filename = "ptdyeplus-1.5.6+forge-1.19.2.jar"
 side = "both"
 
 [download]
 hash-format = "sha1"
-hash = "90e03fd5161a4d12a5a27875ee96b03dba8053eb"
+hash = "80113038a2ead4187bee98b1e239ca0a533490f2"
 mode = "metadata:curseforge"
 
 [update]
 [update.curseforge]
-file-id = 5071961
+file-id = 5072599
 project-id = 952113

--- a/curseforge/pack.toml
+++ b/curseforge/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "333d5c27e0b042d7f517bc0401ce9de66c34593e79138d24c46813a7db2d4540"
+hash = "7af2cc8baba7d2f028005bc24968295bf5d2db427a0bd6db3811feb0f07de0e3"
 
 [versions]
 forge = "43.3.5"

--- a/index.toml
+++ b/index.toml
@@ -8020,7 +8020,7 @@ metafile = true
 
 [[files]]
 file = "mods/ptdye-plus.pw.toml"
-hash = "83d634c7bdd2d336d192f35514812eb800abc5a032073b4028497d9d7f08c790"
+hash = "ca053aa2ccd6d99f4b46c6e09b78f671b4349662f49aa49551502f3204d9c34d"
 metafile = true
 
 [[files]]

--- a/mods/ptdye-plus.pw.toml
+++ b/mods/ptdye-plus.pw.toml
@@ -1,13 +1,13 @@
 name = "Ptdye Plus"
-filename = "ptdyeplus-1.5.6+forge-1.19.2.jar"
+filename = "ptdyeplus-1.5.7+forge-1.19.2.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/P6ripHDK/ptdyeplus-1.5.6%2Bforge-1.19.2.jar"
+url = "https://cdn.modrinth.com/data/ikDjkgLu/versions/calgWuVG/ptdyeplus-1.5.7%2Bforge-1.19.2.jar"
 hash-format = "sha1"
-hash = "6676a5f5c554cd3241a93546695d090575ca67f0"
+hash = "2f3813ff84e0c567f63f6efa6e8bc788698c9391"
 
 [update]
 [update.modrinth]
 mod-id = "ikDjkgLu"
-version = "P6ripHDK"
+version = "calgWuVG"

--- a/pack.toml
+++ b/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "0b2f4dc09c41af3094fe6b1b8857cfde39ddac82d6893abb0b67552d2ef43663"
+hash = "fe777c048422eed69991dbf9c9c41e3955c6500bfa3cdcccfb9a0d53d997cb19"
 
 [versions]
 forge = "43.3.2"


### PR DESCRIPTION
Changelog: ### [1.5.7](https://github.com/game-design-driven/ptdye-plus/compare/1.5.6...1.5.7) (2024-02-03)