### PR TITLE
Fix: added loot fix for iron golem #595

### DIFF
--- a/kubejs/server_scripts/base/loot.js
+++ b/kubejs/server_scripts/base/loot.js
@@ -142,3 +142,11 @@ if (feature('Pillagers drop heads')) {
   })
   
 }
+
+if (feature('Replace white ingot (iron ingot) with white plates')) {
+  LootJS.modifiers((event) => {
+    event
+      .addEntityLootModifier("minecraft:iron_golem")
+      .replaceLoot("minecraft:iron_ingot", "create:iron_sheet", true)
+  }); 
+}


### PR DESCRIPTION
This pull request will be merged when its done, when the following checkboxes are checked and when it passes review.
- [x] - tested and confirmed working
  - [x]  - singleplayer
  - [x] - server
  - [x] - all test cases
      - [x] - Pre-existing iron golems drop iron sheets
      - [x] - New iron golems drop iron sheets
      - [x] - Player kills drop iron sheets
      - [x] - Iron golem vs environment drops iron sheets
      - [x] - Drops the correct number of iron sheets avg ~2-4
        
 
Solution was suggested in #595, slightly modified to keep the correct number of drops as it was only dropping 1 sheet