### PR TITLE
Feat: Make spawn less crazy

### DIFF
--- a/kubejs/data/minecraft/dimension/overworld.json
+++ b/kubejs/data/minecraft/dimension/overworld.json
@@ -9,55 +9,55 @@
         {
           "biome": "minecraft:eroded_badlands",
           "parameters": {
+            "temperature": [
+              -1,
+              1
+            ],
+            "humidity": [
+              -1,
+              -0.35
+            ],
             "continentalness": [
               0.03,
               0.3
             ],
-            "depth": 0.0,
             "erosion": [
               -0.2225,
               0.05
             ],
-            "humidity": [
-              -1.0,
-              -0.35
-            ],
-            "offset": 0.0,
-            "temperature": [
-              0.55,
-              1.0
-            ],
             "weirdness": [
               0.4,
               0.5666
-            ]
+            ],
+            "depth": 0,
+            "offset": 0
           }
         },
         {
           "biome": "minecraft:badlands",
           "parameters": {
+            "temperature": [
+              0.5,
+              2
+            ],
+            "humidity": [
+              -1,
+              -0.35
+            ],
             "continentalness": [
               0.03,
               0.3
             ],
-            "depth": 0.0,
             "erosion": [
-              -1.0,
+              -1,
               -0.7799
-            ],
-            "humidity": [
-              -1.0,
-              -0.35
-            ],
-            "offset": 0.0,
-            "temperature": [
-              0.55,
-              1.0
             ],
             "weirdness": [
               0.4,
               0.5
-            ]
+            ],
+            "depth": 0,
+            "offset": 0
           }
         }
       ]

--- a/kubejs/data/minecraft/worldgen/noise_settings/overworld.json
+++ b/kubejs/data/minecraft/worldgen/noise_settings/overworld.json
@@ -1,5 +1,9 @@
 {
+  "sea_level": 32,
+  "disable_mob_generation": false,
   "aquifers_enabled": true,
+  "ore_veins_enabled": false,
+  "legacy_random_source": false,
   "default_block": {
     "Name": "minecraft:terracotta"
   },
@@ -9,11 +13,9 @@
       "level": "0"
     }
   },
-  "disable_mob_generation": false,
-  "legacy_random_source": false,
   "noise": {
-    "height": 384,
     "min_y": -64,
+    "height": 384,
     "size_horizontal": 1,
     "size_vertical": 2
   },
@@ -21,163 +23,49 @@
     "barrier": {
       "type": "minecraft:noise",
       "noise": "minecraft:aquifer_barrier",
-      "xz_scale": 1.0,
+      "xz_scale": 1,
       "y_scale": 0.5
-    },
-    "continents": "minecraft:overworld/continents",
-    "depth": "minecraft:overworld/depth",
-    "erosion": "minecraft:overworld/erosion",
-    "final_density": {
-      "type": "minecraft:min",
-      "argument1": {
-        "type": "minecraft:squeeze",
-        "argument": {
-          "type": "minecraft:mul",
-          "argument1": 0.64,
-          "argument2": {
-            "type": "minecraft:interpolated",
-            "argument": {
-              "type": "minecraft:blend_density",
-              "argument": {
-                "type": "minecraft:add",
-                "argument1": 0.4,
-                "argument2": {
-                  "type": "minecraft:mul",
-                  "argument1": {
-                    "type": "minecraft:y_clamped_gradient",
-                    "from_value": 0.0,
-                    "from_y": -64,
-                    "to_value": 1.0,
-                    "to_y": -40
-                  },
-                  "argument2": {
-                    "type": "minecraft:add",
-                    "argument1": -0.4,
-                    "argument2": {
-                      "type": "minecraft:add",
-                      "argument1": -0.078125,
-                      "argument2": {
-                        "type": "minecraft:mul",
-                        "argument1": {
-                          "type": "minecraft:y_clamped_gradient",
-                          "from_value": 1.0,
-                          "from_y": 304,
-                          "to_value": 0.0,
-                          "to_y": 320
-                        },
-                        "argument2": {
-                          "type": "minecraft:add",
-                          "argument1": 0.078125,
-                          "argument2": {
-                            "type": "minecraft:range_choice",
-                            "input": "minecraft:overworld_amplified/sloped_cheese",
-                            "max_exclusive": 1.5625,
-                            "min_inclusive": -1000000.0,
-                            "when_in_range": {
-                              "type": "minecraft:min",
-                              "argument1": "minecraft:overworld_amplified/sloped_cheese",
-                              "argument2": {
-                                "type": "minecraft:mul",
-                                "argument1": 5.0,
-                                "argument2": "minecraft:overworld/caves/entrances"
-                              }
-                            },
-                            "when_out_of_range": {
-                              "type": "minecraft:max",
-                              "argument1": {
-                                "type": "minecraft:min",
-                                "argument1": {
-                                  "type": "minecraft:min",
-                                  "argument1": {
-                                    "type": "minecraft:add",
-                                    "argument1": {
-                                      "type": "minecraft:mul",
-                                      "argument1": 4.0,
-                                      "argument2": {
-                                        "type": "minecraft:square",
-                                        "argument": {
-                                          "type": "minecraft:noise",
-                                          "noise": "minecraft:cave_layer",
-                                          "xz_scale": 1.0,
-                                          "y_scale": 8.0
-                                        }
-                                      }
-                                    },
-                                    "argument2": {
-                                      "type": "minecraft:add",
-                                      "argument1": {
-                                        "type": "minecraft:clamp",
-                                        "input": {
-                                          "type": "minecraft:add",
-                                          "argument1": 0.27,
-                                          "argument2": {
-                                            "type": "minecraft:noise",
-                                            "noise": "minecraft:cave_cheese",
-                                            "xz_scale": 1.0,
-                                            "y_scale": 0.6666666666666666
-                                          }
-                                        },
-                                        "max": 1.0,
-                                        "min": -1.0
-                                      },
-                                      "argument2": {
-                                        "type": "minecraft:clamp",
-                                        "input": {
-                                          "type": "minecraft:add",
-                                          "argument1": 1.5,
-                                          "argument2": {
-                                            "type": "minecraft:mul",
-                                            "argument1": -0.64,
-                                            "argument2": "minecraft:overworld_amplified/sloped_cheese"
-                                          }
-                                        },
-                                        "max": 0.5,
-                                        "min": 0.0
-                                      }
-                                    }
-                                  },
-                                  "argument2": "minecraft:overworld/caves/entrances"
-                                },
-                                "argument2": {
-                                  "type": "minecraft:add",
-                                  "argument1": "minecraft:overworld/caves/spaghetti_2d",
-                                  "argument2": "minecraft:overworld/caves/spaghetti_roughness_function"
-                                }
-                              },
-                              "argument2": {
-                                "type": "minecraft:range_choice",
-                                "input": "minecraft:overworld/caves/pillars",
-                                "max_exclusive": 0.03,
-                                "min_inclusive": -1000000.0,
-                                "when_in_range": -1000000.0,
-                                "when_out_of_range": "minecraft:overworld/caves/pillars"
-                              }
-                            }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-            }
-          }
-        }
-      },
-      "argument2": "minecraft:overworld/caves/noodle"
     },
     "fluid_level_floodedness": {
       "type": "minecraft:noise",
       "noise": "minecraft:aquifer_fluid_level_floodedness",
-      "xz_scale": 1.0,
+      "xz_scale": 1,
       "y_scale": 0.67
     },
     "fluid_level_spread": {
       "type": "minecraft:noise",
       "noise": "minecraft:aquifer_fluid_level_spread",
-      "xz_scale": 1.0,
+      "xz_scale": 1,
       "y_scale": 0.7142857142857143
     },
+    "lava": {
+      "type": "minecraft:noise",
+      "noise": "minecraft:aquifer_lava",
+      "xz_scale": 1,
+      "y_scale": 1
+    },
+    "temperature": {
+      "type": "minecraft:shifted_noise",
+      "noise": "minecraft:temperature",
+      "xz_scale": 0.25,
+      "y_scale": 0,
+      "shift_x": "minecraft:shift_x",
+      "shift_y": 0,
+      "shift_z": "minecraft:shift_z"
+    },
+    "vegetation": {
+      "type": "minecraft:shifted_noise",
+      "noise": "minecraft:vegetation",
+      "xz_scale": 0.25,
+      "y_scale": 0,
+      "shift_x": "minecraft:shift_x",
+      "shift_y": 0,
+      "shift_z": "minecraft:shift_z"
+    },
+    "continents": "minecraft:overworld/continents",
+    "erosion": "minecraft:overworld/erosion",
+    "depth": "minecraft:overworld/depth",
+    "ridges": "minecraft:overworld/ridges",
     "initial_density_without_jaggedness": {
       "type": "minecraft:add",
       "argument1": 0.4,
@@ -185,10 +73,10 @@
         "type": "minecraft:mul",
         "argument1": {
           "type": "minecraft:y_clamped_gradient",
-          "from_value": 0.0,
           "from_y": -64,
-          "to_value": 1.0,
-          "to_y": -40
+          "to_y": -40,
+          "from_value": 0,
+          "to_value": 1
         },
         "argument2": {
           "type": "minecraft:add",
@@ -200,10 +88,10 @@
               "type": "minecraft:mul",
               "argument1": {
                 "type": "minecraft:y_clamped_gradient",
-                "from_value": 1.0,
                 "from_y": 304,
-                "to_value": 0.0,
-                "to_y": 320
+                "to_y": 320,
+                "from_value": 1,
+                "to_value": 0
               },
               "argument2": {
                 "type": "minecraft:add",
@@ -215,7 +103,7 @@
                     "argument1": -0.703125,
                     "argument2": {
                       "type": "minecraft:mul",
-                      "argument1": 4.0,
+                      "argument1": 4,
                       "argument2": {
                         "type": "minecraft:quarter_negative",
                         "argument": {
@@ -229,8 +117,8 @@
                       }
                     }
                   },
-                  "max": 64.0,
-                  "min": -64.0
+                  "min": -64,
+                  "max": 64
                 }
               }
             }
@@ -238,36 +126,22 @@
         }
       }
     },
-    "lava": {
-      "type": "minecraft:noise",
-      "noise": "minecraft:aquifer_lava",
-      "xz_scale": 1.0,
-      "y_scale": 1.0
-    },
-    "ridges": "minecraft:overworld/ridges",
-    "temperature": {
-      "type": "minecraft:shifted_noise",
-      "noise": "minecraft:temperature",
-      "shift_x": "minecraft:shift_x",
-      "shift_y": 0.0,
-      "shift_z": "minecraft:shift_z",
-      "xz_scale": 0.25,
-      "y_scale": 0.0
-    },
-    "vegetation": {
-      "type": "minecraft:shifted_noise",
-      "noise": "minecraft:vegetation",
-      "shift_x": "minecraft:shift_x",
-      "shift_y": 0.0,
-      "shift_z": "minecraft:shift_z",
-      "xz_scale": 0.25,
-      "y_scale": 0.0
-    },
-    "vein_gap": {
-      "type": "minecraft:noise",
-      "noise": "minecraft:ore_gap",
-      "xz_scale": 1.0,
-      "y_scale": 1.0
+    "final_density": "minecraft:final_density",
+    "vein_toggle": {
+      "type": "minecraft:interpolated",
+      "argument": {
+        "type": "minecraft:range_choice",
+        "input": "minecraft:y",
+        "min_inclusive": -60,
+        "max_exclusive": 51,
+        "when_in_range": {
+          "type": "minecraft:noise",
+          "noise": "minecraft:ore_veininess",
+          "xz_scale": 1.5,
+          "y_scale": 1.5
+        },
+        "when_out_of_range": 0
+      }
     },
     "vein_ridged": {
       "type": "minecraft:add",
@@ -281,15 +155,15 @@
             "argument": {
               "type": "minecraft:range_choice",
               "input": "minecraft:y",
-              "max_exclusive": 51.0,
-              "min_inclusive": -60.0,
+              "min_inclusive": -60,
+              "max_exclusive": 51,
               "when_in_range": {
                 "type": "minecraft:noise",
                 "noise": "minecraft:ore_vein_a",
-                "xz_scale": 4.0,
-                "y_scale": 4.0
+                "xz_scale": 4,
+                "y_scale": 4
               },
-              "when_out_of_range": 0.0
+              "when_out_of_range": 0
             }
           }
         },
@@ -300,87 +174,75 @@
             "argument": {
               "type": "minecraft:range_choice",
               "input": "minecraft:y",
-              "max_exclusive": 51.0,
-              "min_inclusive": -60.0,
+              "min_inclusive": -60,
+              "max_exclusive": 51,
               "when_in_range": {
                 "type": "minecraft:noise",
                 "noise": "minecraft:ore_vein_b",
-                "xz_scale": 4.0,
-                "y_scale": 4.0
+                "xz_scale": 4,
+                "y_scale": 4
               },
-              "when_out_of_range": 0.0
+              "when_out_of_range": 0
             }
           }
         }
       }
     },
-    "vein_toggle": {
-      "type": "minecraft:interpolated",
-      "argument": {
-        "type": "minecraft:range_choice",
-        "input": "minecraft:y",
-        "max_exclusive": 51.0,
-        "min_inclusive": -60.0,
-        "when_in_range": {
-          "type": "minecraft:noise",
-          "noise": "minecraft:ore_veininess",
-          "xz_scale": 1.5,
-          "y_scale": 1.5
-        },
-        "when_out_of_range": 0.0
-      }
+    "vein_gap": {
+      "type": "minecraft:noise",
+      "noise": "minecraft:ore_gap",
+      "xz_scale": 1,
+      "y_scale": 1
     }
   },
-  "ore_veins_enabled": false,
-  "sea_level": 32,
   "spawn_target": [
     {
-      "continentalness": [
-        -0.11,
-        1.0
-      ],
-      "depth": 0.0,
-      "erosion": [
-        -1.0,
-        1.0
+      "temperature": [
+        -1,
+        1
       ],
       "humidity": [
-        -1.0,
-        1.0
+        -1,
+        1
       ],
-      "offset": 0.0,
-      "temperature": [
-        -1.0,
-        1.0
+      "continentalness": [
+        -0.11,
+        1
+      ],
+      "erosion": [
+        -1,
+        1
       ],
       "weirdness": [
-        -1.0,
+        -1,
         -0.16
-      ]
+      ],
+      "depth": 0,
+      "offset": 0
     },
     {
-      "continentalness": [
-        -0.11,
-        1.0
-      ],
-      "depth": 0.0,
-      "erosion": [
-        -1.0,
-        1.0
+      "temperature": [
+        -1,
+        1
       ],
       "humidity": [
-        -1.0,
-        1.0
+        -1,
+        1
       ],
-      "offset": 0.0,
-      "temperature": [
-        -1.0,
-        1.0
+      "continentalness": [
+        -0.11,
+        1
+      ],
+      "erosion": [
+        -1,
+        1
       ],
       "weirdness": [
         0.16,
-        1.0
-      ]
+        1
+      ],
+      "depth": 0,
+      "offset": 0
     }
   ],
   "surface_rule": {
@@ -390,12 +252,12 @@
         "type": "minecraft:condition",
         "if_true": {
           "type": "minecraft:vertical_gradient",
-          "false_at_and_above": {
-            "above_bottom": 5
-          },
           "random_name": "minecraft:bedrock_floor",
           "true_at_and_below": {
             "above_bottom": 0
+          },
+          "false_at_and_above": {
+            "above_bottom": 5
           }
         },
         "then_run": {
@@ -417,10 +279,10 @@
               "type": "minecraft:condition",
               "if_true": {
                 "type": "minecraft:stone_depth",
-                "add_surface_depth": false,
                 "offset": 0,
-                "secondary_depth_range": 0,
-                "surface_type": "floor"
+                "surface_type": "floor",
+                "add_surface_depth": false,
+                "secondary_depth_range": 0
               },
               "then_run": {
                 "type": "minecraft:sequence",
@@ -437,11 +299,11 @@
                       "type": "minecraft:condition",
                       "if_true": {
                         "type": "minecraft:y_above",
-                        "add_stone_depth": false,
                         "anchor": {
                           "absolute": 97
                         },
-                        "surface_depth_multiplier": 2
+                        "surface_depth_multiplier": 2,
+                        "add_stone_depth": false
                       },
                       "then_run": {
                         "type": "minecraft:sequence",
@@ -450,9 +312,9 @@
                             "type": "minecraft:condition",
                             "if_true": {
                               "type": "minecraft:noise_threshold",
-                              "max_threshold": -0.5454,
+                              "noise": "minecraft:surface",
                               "min_threshold": -0.909,
-                              "noise": "minecraft:surface"
+                              "max_threshold": -0.5454
                             },
                             "then_run": {
                               "type": "minecraft:block",
@@ -465,9 +327,9 @@
                             "type": "minecraft:condition",
                             "if_true": {
                               "type": "minecraft:noise_threshold",
-                              "max_threshold": 0.1818,
+                              "noise": "minecraft:surface",
                               "min_threshold": -0.1818,
-                              "noise": "minecraft:surface"
+                              "max_threshold": 0.1818
                             },
                             "then_run": {
                               "type": "minecraft:block",
@@ -480,9 +342,9 @@
                             "type": "minecraft:condition",
                             "if_true": {
                               "type": "minecraft:noise_threshold",
-                              "max_threshold": 0.909,
+                              "noise": "minecraft:surface",
                               "min_threshold": 0.5454,
-                              "noise": "minecraft:surface"
+                              "max_threshold": 0.909
                             },
                             "then_run": {
                               "type": "minecraft:block",
@@ -498,9 +360,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:water",
-                                  "add_stone_depth": false,
                                   "offset": 0,
-                                  "surface_depth_multiplier": 0
+                                  "surface_depth_multiplier": 0,
+                                  "add_stone_depth": false
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -536,11 +398,11 @@
                       "type": "minecraft:condition",
                       "if_true": {
                         "type": "minecraft:y_above",
-                        "add_stone_depth": false,
                         "anchor": {
                           "absolute": 62
                         },
-                        "surface_depth_multiplier": 0
+                        "surface_depth_multiplier": 0,
+                        "add_stone_depth": false
                       },
                       "then_run": {
                         "type": "minecraft:condition",
@@ -548,20 +410,20 @@
                           "type": "minecraft:not",
                           "invert": {
                             "type": "minecraft:y_above",
-                            "add_stone_depth": false,
                             "anchor": {
                               "absolute": 63
                             },
-                            "surface_depth_multiplier": 0
+                            "surface_depth_multiplier": 0,
+                            "add_stone_depth": false
                           }
                         },
                         "then_run": {
                           "type": "minecraft:condition",
                           "if_true": {
                             "type": "minecraft:noise_threshold",
-                            "max_threshold": 1.7976931348623157E308,
-                            "min_threshold": 0.0,
-                            "noise": "minecraft:surface_swamp"
+                            "noise": "minecraft:surface_swamp",
+                            "min_threshold": 0,
+                            "max_threshold": 1.7976931348623157e+308
                           },
                           "then_run": {
                             "type": "minecraft:block",
@@ -588,11 +450,11 @@
                       "type": "minecraft:condition",
                       "if_true": {
                         "type": "minecraft:y_above",
-                        "add_stone_depth": false,
                         "anchor": {
                           "absolute": 60
                         },
-                        "surface_depth_multiplier": 0
+                        "surface_depth_multiplier": 0,
+                        "add_stone_depth": false
                       },
                       "then_run": {
                         "type": "minecraft:condition",
@@ -600,20 +462,20 @@
                           "type": "minecraft:not",
                           "invert": {
                             "type": "minecraft:y_above",
-                            "add_stone_depth": false,
                             "anchor": {
                               "absolute": 63
                             },
-                            "surface_depth_multiplier": 0
+                            "surface_depth_multiplier": 0,
+                            "add_stone_depth": false
                           }
                         },
                         "then_run": {
                           "type": "minecraft:condition",
                           "if_true": {
                             "type": "minecraft:noise_threshold",
-                            "max_threshold": 1.7976931348623157E308,
-                            "min_threshold": 0.0,
-                            "noise": "minecraft:surface_swamp"
+                            "noise": "minecraft:surface_swamp",
+                            "min_threshold": 0,
+                            "max_threshold": 1.7976931348623157e+308
                           },
                           "then_run": {
                             "type": "minecraft:block",
@@ -648,10 +510,10 @@
                     "type": "minecraft:condition",
                     "if_true": {
                       "type": "minecraft:stone_depth",
-                      "add_surface_depth": false,
                       "offset": 0,
-                      "secondary_depth_range": 0,
-                      "surface_type": "floor"
+                      "surface_type": "floor",
+                      "add_surface_depth": false,
+                      "secondary_depth_range": 0
                     },
                     "then_run": {
                       "type": "minecraft:sequence",
@@ -660,11 +522,11 @@
                           "type": "minecraft:condition",
                           "if_true": {
                             "type": "minecraft:y_above",
-                            "add_stone_depth": false,
                             "anchor": {
                               "absolute": 256
                             },
-                            "surface_depth_multiplier": 0
+                            "surface_depth_multiplier": 0,
+                            "add_stone_depth": false
                           },
                           "then_run": {
                             "type": "minecraft:block",
@@ -677,11 +539,11 @@
                           "type": "minecraft:condition",
                           "if_true": {
                             "type": "minecraft:y_above",
-                            "add_stone_depth": true,
                             "anchor": {
                               "absolute": 74
                             },
-                            "surface_depth_multiplier": 1
+                            "surface_depth_multiplier": 1,
+                            "add_stone_depth": true
                           },
                           "then_run": {
                             "type": "minecraft:sequence",
@@ -690,9 +552,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": -0.5454,
+                                  "noise": "minecraft:surface",
                                   "min_threshold": -0.909,
-                                  "noise": "minecraft:surface"
+                                  "max_threshold": -0.5454
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -705,9 +567,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 0.1818,
+                                  "noise": "minecraft:surface",
                                   "min_threshold": -0.1818,
-                                  "noise": "minecraft:surface"
+                                  "max_threshold": 0.1818
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -720,9 +582,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 0.909,
+                                  "noise": "minecraft:surface",
                                   "min_threshold": 0.5454,
-                                  "noise": "minecraft:surface"
+                                  "max_threshold": 0.909
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -741,9 +603,9 @@
                           "type": "minecraft:condition",
                           "if_true": {
                             "type": "minecraft:water",
-                            "add_stone_depth": false,
                             "offset": -1,
-                            "surface_depth_multiplier": 0
+                            "surface_depth_multiplier": 0,
+                            "add_stone_depth": false
                           },
                           "then_run": {
                             "type": "minecraft:sequence",
@@ -752,10 +614,10 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:stone_depth",
-                                  "add_surface_depth": false,
                                   "offset": 0,
-                                  "secondary_depth_range": 0,
-                                  "surface_type": "ceiling"
+                                  "surface_type": "ceiling",
+                                  "add_surface_depth": false,
+                                  "secondary_depth_range": 0
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -792,9 +654,9 @@
                           "type": "minecraft:condition",
                           "if_true": {
                             "type": "minecraft:water",
-                            "add_stone_depth": true,
                             "offset": -6,
-                            "surface_depth_multiplier": -1
+                            "surface_depth_multiplier": -1,
+                            "add_stone_depth": true
                           },
                           "then_run": {
                             "type": "minecraft:block",
@@ -810,10 +672,10 @@
                               "type": "minecraft:condition",
                               "if_true": {
                                 "type": "minecraft:stone_depth",
-                                "add_surface_depth": false,
                                 "offset": 0,
-                                "secondary_depth_range": 0,
-                                "surface_type": "ceiling"
+                                "surface_type": "ceiling",
+                                "add_surface_depth": false,
+                                "secondary_depth_range": 0
                               },
                               "then_run": {
                                 "type": "minecraft:block",
@@ -837,11 +699,11 @@
                     "type": "minecraft:condition",
                     "if_true": {
                       "type": "minecraft:y_above",
-                      "add_stone_depth": true,
                       "anchor": {
                         "absolute": 63
                       },
-                      "surface_depth_multiplier": -1
+                      "surface_depth_multiplier": -1,
+                      "add_stone_depth": true
                     },
                     "then_run": {
                       "type": "minecraft:sequence",
@@ -850,11 +712,11 @@
                           "type": "minecraft:condition",
                           "if_true": {
                             "type": "minecraft:y_above",
-                            "add_stone_depth": false,
                             "anchor": {
                               "absolute": 63
                             },
-                            "surface_depth_multiplier": 0
+                            "surface_depth_multiplier": 0,
+                            "add_stone_depth": false
                           },
                           "then_run": {
                             "type": "minecraft:condition",
@@ -862,11 +724,11 @@
                               "type": "minecraft:not",
                               "invert": {
                                 "type": "minecraft:y_above",
-                                "add_stone_depth": true,
                                 "anchor": {
                                   "absolute": 74
                                 },
-                                "surface_depth_multiplier": 1
+                                "surface_depth_multiplier": 1,
+                                "add_stone_depth": true
                               }
                             },
                             "then_run": {
@@ -887,18 +749,18 @@
                     "type": "minecraft:condition",
                     "if_true": {
                       "type": "minecraft:stone_depth",
-                      "add_surface_depth": true,
                       "offset": 0,
-                      "secondary_depth_range": 0,
-                      "surface_type": "floor"
+                      "surface_type": "floor",
+                      "add_surface_depth": true,
+                      "secondary_depth_range": 0
                     },
                     "then_run": {
                       "type": "minecraft:condition",
                       "if_true": {
                         "type": "minecraft:water",
-                        "add_stone_depth": true,
                         "offset": -6,
-                        "surface_depth_multiplier": -1
+                        "surface_depth_multiplier": -1,
+                        "add_stone_depth": true
                       },
                       "then_run": {
                         "type": "minecraft:block",
@@ -915,18 +777,18 @@
               "type": "minecraft:condition",
               "if_true": {
                 "type": "minecraft:stone_depth",
-                "add_surface_depth": false,
                 "offset": 0,
-                "secondary_depth_range": 0,
-                "surface_type": "floor"
+                "surface_type": "floor",
+                "add_surface_depth": false,
+                "secondary_depth_range": 0
               },
               "then_run": {
                 "type": "minecraft:condition",
                 "if_true": {
                   "type": "minecraft:water",
-                  "add_stone_depth": false,
                   "offset": -1,
-                  "surface_depth_multiplier": 0
+                  "surface_depth_multiplier": 0,
+                  "add_stone_depth": false
                 },
                 "then_run": {
                   "type": "minecraft:sequence",
@@ -952,9 +814,9 @@
                               "type": "minecraft:condition",
                               "if_true": {
                                 "type": "minecraft:water",
-                                "add_stone_depth": false,
                                 "offset": 0,
-                                "surface_depth_multiplier": 0
+                                "surface_depth_multiplier": 0,
+                                "add_stone_depth": false
                               },
                               "then_run": {
                                 "type": "minecraft:block",
@@ -1018,9 +880,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 0.2,
-                                  "min_threshold": 0.0,
-                                  "noise": "minecraft:packed_ice"
+                                  "noise": "minecraft:packed_ice",
+                                  "min_threshold": 0,
+                                  "max_threshold": 0.2
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -1033,9 +895,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 0.025,
-                                  "min_threshold": 0.0,
-                                  "noise": "minecraft:ice"
+                                  "noise": "minecraft:ice",
+                                  "min_threshold": 0,
+                                  "max_threshold": 0.025
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -1048,9 +910,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:water",
-                                  "add_stone_depth": false,
                                   "offset": 0,
-                                  "surface_depth_multiplier": 0
+                                  "surface_depth_multiplier": 0,
+                                  "add_stone_depth": false
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -1089,17 +951,17 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 0.6,
+                                  "noise": "minecraft:powder_snow",
                                   "min_threshold": 0.35,
-                                  "noise": "minecraft:powder_snow"
+                                  "max_threshold": 0.6
                                 },
                                 "then_run": {
                                   "type": "minecraft:condition",
                                   "if_true": {
                                     "type": "minecraft:water",
-                                    "add_stone_depth": false,
                                     "offset": 0,
-                                    "surface_depth_multiplier": 0
+                                    "surface_depth_multiplier": 0,
+                                    "add_stone_depth": false
                                   },
                                   "then_run": {
                                     "type": "minecraft:block",
@@ -1113,9 +975,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:water",
-                                  "add_stone_depth": false,
                                   "offset": 0,
-                                  "surface_depth_multiplier": 0
+                                  "surface_depth_multiplier": 0,
+                                  "add_stone_depth": false
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -1154,9 +1016,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:water",
-                                  "add_stone_depth": false,
                                   "offset": 0,
-                                  "surface_depth_multiplier": 0
+                                  "surface_depth_multiplier": 0,
+                                  "add_stone_depth": false
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -1183,17 +1045,17 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 0.6,
+                                  "noise": "minecraft:powder_snow",
                                   "min_threshold": 0.35,
-                                  "noise": "minecraft:powder_snow"
+                                  "max_threshold": 0.6
                                 },
                                 "then_run": {
                                   "type": "minecraft:condition",
                                   "if_true": {
                                     "type": "minecraft:water",
-                                    "add_stone_depth": false,
                                     "offset": 0,
-                                    "surface_depth_multiplier": 0
+                                    "surface_depth_multiplier": 0,
+                                    "add_stone_depth": false
                                   },
                                   "then_run": {
                                     "type": "minecraft:block",
@@ -1207,9 +1069,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:water",
-                                  "add_stone_depth": false,
                                   "offset": 0,
-                                  "surface_depth_multiplier": 0
+                                  "surface_depth_multiplier": 0,
+                                  "add_stone_depth": false
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -1239,9 +1101,9 @@
                                     "type": "minecraft:condition",
                                     "if_true": {
                                       "type": "minecraft:noise_threshold",
-                                      "max_threshold": 0.0125,
+                                      "noise": "minecraft:calcite",
                                       "min_threshold": -0.0125,
-                                      "noise": "minecraft:calcite"
+                                      "max_threshold": 0.0125
                                     },
                                     "then_run": {
                                       "type": "minecraft:block",
@@ -1274,9 +1136,9 @@
                                     "type": "minecraft:condition",
                                     "if_true": {
                                       "type": "minecraft:noise_threshold",
-                                      "max_threshold": 0.05,
+                                      "noise": "minecraft:gravel",
                                       "min_threshold": -0.05,
-                                      "noise": "minecraft:gravel"
+                                      "max_threshold": 0.05
                                     },
                                     "then_run": {
                                       "type": "minecraft:sequence",
@@ -1285,10 +1147,10 @@
                                           "type": "minecraft:condition",
                                           "if_true": {
                                             "type": "minecraft:stone_depth",
-                                            "add_surface_depth": false,
                                             "offset": 0,
-                                            "secondary_depth_range": 0,
-                                            "surface_type": "ceiling"
+                                            "surface_type": "ceiling",
+                                            "add_surface_depth": false,
+                                            "secondary_depth_range": 0
                                           },
                                           "then_run": {
                                             "type": "minecraft:block",
@@ -1327,9 +1189,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 1.7976931348623157E308,
+                                  "noise": "minecraft:surface",
                                   "min_threshold": 0.12121212121212122,
-                                  "noise": "minecraft:surface"
+                                  "max_threshold": 1.7976931348623157e+308
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -1356,10 +1218,10 @@
                                     "type": "minecraft:condition",
                                     "if_true": {
                                       "type": "minecraft:stone_depth",
-                                      "add_surface_depth": false,
                                       "offset": 0,
-                                      "secondary_depth_range": 0,
-                                      "surface_type": "ceiling"
+                                      "surface_type": "ceiling",
+                                      "add_surface_depth": false,
+                                      "secondary_depth_range": 0
                                     },
                                     "then_run": {
                                       "type": "minecraft:block",
@@ -1392,10 +1254,10 @@
                                     "type": "minecraft:condition",
                                     "if_true": {
                                       "type": "minecraft:stone_depth",
-                                      "add_surface_depth": false,
                                       "offset": 0,
-                                      "secondary_depth_range": 0,
-                                      "surface_type": "ceiling"
+                                      "surface_type": "ceiling",
+                                      "add_surface_depth": false,
+                                      "secondary_depth_range": 0
                                     },
                                     "then_run": {
                                       "type": "minecraft:block",
@@ -1445,9 +1307,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 1.7976931348623157E308,
+                                  "noise": "minecraft:surface",
                                   "min_threshold": 0.21212121212121213,
-                                  "noise": "minecraft:surface"
+                                  "max_threshold": 1.7976931348623157e+308
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -1460,9 +1322,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 1.7976931348623157E308,
+                                  "noise": "minecraft:surface",
                                   "min_threshold": -0.06060606060606061,
-                                  "noise": "minecraft:surface"
+                                  "max_threshold": 1.7976931348623157e+308
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -1489,9 +1351,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 1.7976931348623157E308,
+                                  "noise": "minecraft:surface",
                                   "min_threshold": 0.24242424242424243,
-                                  "noise": "minecraft:surface"
+                                  "max_threshold": 1.7976931348623157e+308
                                 },
                                 "then_run": {
                                   "type": "minecraft:sequence",
@@ -1500,10 +1362,10 @@
                                       "type": "minecraft:condition",
                                       "if_true": {
                                         "type": "minecraft:stone_depth",
-                                        "add_surface_depth": false,
                                         "offset": 0,
-                                        "secondary_depth_range": 0,
-                                        "surface_type": "ceiling"
+                                        "surface_type": "ceiling",
+                                        "add_surface_depth": false,
+                                        "secondary_depth_range": 0
                                       },
                                       "then_run": {
                                         "type": "minecraft:block",
@@ -1525,9 +1387,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 1.7976931348623157E308,
+                                  "noise": "minecraft:surface",
                                   "min_threshold": 0.12121212121212122,
-                                  "noise": "minecraft:surface"
+                                  "max_threshold": 1.7976931348623157e+308
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -1540,9 +1402,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 1.7976931348623157E308,
+                                  "noise": "minecraft:surface",
                                   "min_threshold": -0.12121212121212122,
-                                  "noise": "minecraft:surface"
+                                  "max_threshold": 1.7976931348623157e+308
                                 },
                                 "then_run": {
                                   "type": "minecraft:sequence",
@@ -1551,9 +1413,9 @@
                                       "type": "minecraft:condition",
                                       "if_true": {
                                         "type": "minecraft:water",
-                                        "add_stone_depth": false,
                                         "offset": 0,
-                                        "surface_depth_multiplier": 0
+                                        "surface_depth_multiplier": 0,
+                                        "add_stone_depth": false
                                       },
                                       "then_run": {
                                         "type": "minecraft:block",
@@ -1581,10 +1443,10 @@
                                     "type": "minecraft:condition",
                                     "if_true": {
                                       "type": "minecraft:stone_depth",
-                                      "add_surface_depth": false,
                                       "offset": 0,
-                                      "secondary_depth_range": 0,
-                                      "surface_type": "ceiling"
+                                      "surface_type": "ceiling",
+                                      "add_surface_depth": false,
+                                      "secondary_depth_range": 0
                                     },
                                     "then_run": {
                                       "type": "minecraft:block",
@@ -1620,9 +1482,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 1.7976931348623157E308,
+                                  "noise": "minecraft:surface",
                                   "min_threshold": 0.21212121212121213,
-                                  "noise": "minecraft:surface"
+                                  "max_threshold": 1.7976931348623157e+308
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -1635,9 +1497,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 1.7976931348623157E308,
+                                  "noise": "minecraft:surface",
                                   "min_threshold": -0.11515151515151514,
-                                  "noise": "minecraft:surface"
+                                  "max_threshold": 1.7976931348623157e+308
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -1664,9 +1526,9 @@
                             "type": "minecraft:condition",
                             "if_true": {
                               "type": "minecraft:water",
-                              "add_stone_depth": false,
                               "offset": 0,
-                              "surface_depth_multiplier": 0
+                              "surface_depth_multiplier": 0,
+                              "add_stone_depth": false
                             },
                             "then_run": {
                               "type": "minecraft:block",
@@ -1716,9 +1578,9 @@
                               "type": "minecraft:condition",
                               "if_true": {
                                 "type": "minecraft:water",
-                                "add_stone_depth": false,
                                 "offset": 0,
-                                "surface_depth_multiplier": 0
+                                "surface_depth_multiplier": 0,
+                                "add_stone_depth": false
                               },
                               "then_run": {
                                 "type": "minecraft:block",
@@ -1748,9 +1610,9 @@
               "type": "minecraft:condition",
               "if_true": {
                 "type": "minecraft:water",
-                "add_stone_depth": true,
                 "offset": -6,
-                "surface_depth_multiplier": -1
+                "surface_depth_multiplier": -1,
+                "add_stone_depth": true
               },
               "then_run": {
                 "type": "minecraft:sequence",
@@ -1759,10 +1621,10 @@
                     "type": "minecraft:condition",
                     "if_true": {
                       "type": "minecraft:stone_depth",
-                      "add_surface_depth": false,
                       "offset": 0,
-                      "secondary_depth_range": 0,
-                      "surface_type": "floor"
+                      "surface_type": "floor",
+                      "add_surface_depth": false,
+                      "secondary_depth_range": 0
                     },
                     "then_run": {
                       "type": "minecraft:condition",
@@ -1794,10 +1656,10 @@
                     "type": "minecraft:condition",
                     "if_true": {
                       "type": "minecraft:stone_depth",
-                      "add_surface_depth": true,
                       "offset": 0,
-                      "secondary_depth_range": 0,
-                      "surface_type": "floor"
+                      "surface_type": "floor",
+                      "add_surface_depth": true,
+                      "secondary_depth_range": 0
                     },
                     "then_run": {
                       "type": "minecraft:sequence",
@@ -1829,9 +1691,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 0.2,
+                                  "noise": "minecraft:packed_ice",
                                   "min_threshold": -0.5,
-                                  "noise": "minecraft:packed_ice"
+                                  "max_threshold": 0.2
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -1844,9 +1706,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 0.025,
+                                  "noise": "minecraft:ice",
                                   "min_threshold": -0.0625,
-                                  "noise": "minecraft:ice"
+                                  "max_threshold": 0.025
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -1859,9 +1721,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:water",
-                                  "add_stone_depth": false,
                                   "offset": 0,
-                                  "surface_depth_multiplier": 0
+                                  "surface_depth_multiplier": 0,
+                                  "add_stone_depth": false
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -1900,17 +1762,17 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 0.58,
+                                  "noise": "minecraft:powder_snow",
                                   "min_threshold": 0.45,
-                                  "noise": "minecraft:powder_snow"
+                                  "max_threshold": 0.58
                                 },
                                 "then_run": {
                                   "type": "minecraft:condition",
                                   "if_true": {
                                     "type": "minecraft:water",
-                                    "add_stone_depth": false,
                                     "offset": 0,
-                                    "surface_depth_multiplier": 0
+                                    "surface_depth_multiplier": 0,
+                                    "add_stone_depth": false
                                   },
                                   "then_run": {
                                     "type": "minecraft:block",
@@ -1924,9 +1786,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:water",
-                                  "add_stone_depth": false,
                                   "offset": 0,
-                                  "surface_depth_multiplier": 0
+                                  "surface_depth_multiplier": 0,
+                                  "add_stone_depth": false
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -1968,17 +1830,17 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 0.58,
+                                  "noise": "minecraft:powder_snow",
                                   "min_threshold": 0.45,
-                                  "noise": "minecraft:powder_snow"
+                                  "max_threshold": 0.58
                                 },
                                 "then_run": {
                                   "type": "minecraft:condition",
                                   "if_true": {
                                     "type": "minecraft:water",
-                                    "add_stone_depth": false,
                                     "offset": 0,
-                                    "surface_depth_multiplier": 0
+                                    "surface_depth_multiplier": 0,
+                                    "add_stone_depth": false
                                   },
                                   "then_run": {
                                     "type": "minecraft:block",
@@ -2015,9 +1877,9 @@
                                     "type": "minecraft:condition",
                                     "if_true": {
                                       "type": "minecraft:noise_threshold",
-                                      "max_threshold": 0.0125,
+                                      "noise": "minecraft:calcite",
                                       "min_threshold": -0.0125,
-                                      "noise": "minecraft:calcite"
+                                      "max_threshold": 0.0125
                                     },
                                     "then_run": {
                                       "type": "minecraft:block",
@@ -2050,9 +1912,9 @@
                                     "type": "minecraft:condition",
                                     "if_true": {
                                       "type": "minecraft:noise_threshold",
-                                      "max_threshold": 0.05,
+                                      "noise": "minecraft:gravel",
                                       "min_threshold": -0.05,
-                                      "noise": "minecraft:gravel"
+                                      "max_threshold": 0.05
                                     },
                                     "then_run": {
                                       "type": "minecraft:sequence",
@@ -2061,10 +1923,10 @@
                                           "type": "minecraft:condition",
                                           "if_true": {
                                             "type": "minecraft:stone_depth",
-                                            "add_surface_depth": false,
                                             "offset": 0,
-                                            "secondary_depth_range": 0,
-                                            "surface_type": "ceiling"
+                                            "surface_type": "ceiling",
+                                            "add_surface_depth": false,
+                                            "secondary_depth_range": 0
                                           },
                                           "then_run": {
                                             "type": "minecraft:block",
@@ -2103,9 +1965,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 1.7976931348623157E308,
+                                  "noise": "minecraft:surface",
                                   "min_threshold": 0.12121212121212122,
-                                  "noise": "minecraft:surface"
+                                  "max_threshold": 1.7976931348623157e+308
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -2132,10 +1994,10 @@
                                     "type": "minecraft:condition",
                                     "if_true": {
                                       "type": "minecraft:stone_depth",
-                                      "add_surface_depth": false,
                                       "offset": 0,
-                                      "secondary_depth_range": 0,
-                                      "surface_type": "ceiling"
+                                      "surface_type": "ceiling",
+                                      "add_surface_depth": false,
+                                      "secondary_depth_range": 0
                                     },
                                     "then_run": {
                                       "type": "minecraft:block",
@@ -2168,10 +2030,10 @@
                                     "type": "minecraft:condition",
                                     "if_true": {
                                       "type": "minecraft:stone_depth",
-                                      "add_surface_depth": false,
                                       "offset": 0,
-                                      "secondary_depth_range": 0,
-                                      "surface_type": "ceiling"
+                                      "surface_type": "ceiling",
+                                      "add_surface_depth": false,
+                                      "secondary_depth_range": 0
                                     },
                                     "then_run": {
                                       "type": "minecraft:block",
@@ -2218,9 +2080,9 @@
                             "type": "minecraft:condition",
                             "if_true": {
                               "type": "minecraft:noise_threshold",
-                              "max_threshold": 1.7976931348623157E308,
+                              "noise": "minecraft:surface",
                               "min_threshold": 0.21212121212121213,
-                              "noise": "minecraft:surface"
+                              "max_threshold": 1.7976931348623157e+308
                             },
                             "then_run": {
                               "type": "minecraft:block",
@@ -2245,9 +2107,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 1.7976931348623157E308,
+                                  "noise": "minecraft:surface",
                                   "min_threshold": 0.24242424242424243,
-                                  "noise": "minecraft:surface"
+                                  "max_threshold": 1.7976931348623157e+308
                                 },
                                 "then_run": {
                                   "type": "minecraft:sequence",
@@ -2256,10 +2118,10 @@
                                       "type": "minecraft:condition",
                                       "if_true": {
                                         "type": "minecraft:stone_depth",
-                                        "add_surface_depth": false,
                                         "offset": 0,
-                                        "secondary_depth_range": 0,
-                                        "surface_type": "ceiling"
+                                        "surface_type": "ceiling",
+                                        "add_surface_depth": false,
+                                        "secondary_depth_range": 0
                                       },
                                       "then_run": {
                                         "type": "minecraft:block",
@@ -2281,9 +2143,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 1.7976931348623157E308,
+                                  "noise": "minecraft:surface",
                                   "min_threshold": 0.12121212121212122,
-                                  "noise": "minecraft:surface"
+                                  "max_threshold": 1.7976931348623157e+308
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -2296,9 +2158,9 @@
                                 "type": "minecraft:condition",
                                 "if_true": {
                                   "type": "minecraft:noise_threshold",
-                                  "max_threshold": 1.7976931348623157E308,
+                                  "noise": "minecraft:surface",
                                   "min_threshold": -0.12121212121212122,
-                                  "noise": "minecraft:surface"
+                                  "max_threshold": 1.7976931348623157e+308
                                 },
                                 "then_run": {
                                   "type": "minecraft:block",
@@ -2314,10 +2176,10 @@
                                     "type": "minecraft:condition",
                                     "if_true": {
                                       "type": "minecraft:stone_depth",
-                                      "add_surface_depth": false,
                                       "offset": 0,
-                                      "secondary_depth_range": 0,
-                                      "surface_type": "ceiling"
+                                      "surface_type": "ceiling",
+                                      "add_surface_depth": false,
+                                      "secondary_depth_range": 0
                                     },
                                     "then_run": {
                                       "type": "minecraft:block",
@@ -2375,10 +2237,10 @@
                       "type": "minecraft:condition",
                       "if_true": {
                         "type": "minecraft:stone_depth",
-                        "add_surface_depth": true,
                         "offset": 0,
-                        "secondary_depth_range": 6,
-                        "surface_type": "floor"
+                        "surface_type": "floor",
+                        "add_surface_depth": true,
+                        "secondary_depth_range": 6
                       },
                       "then_run": {
                         "type": "minecraft:block",
@@ -2400,10 +2262,10 @@
                       "type": "minecraft:condition",
                       "if_true": {
                         "type": "minecraft:stone_depth",
-                        "add_surface_depth": true,
                         "offset": 0,
-                        "secondary_depth_range": 30,
-                        "surface_type": "floor"
+                        "surface_type": "floor",
+                        "add_surface_depth": true,
+                        "secondary_depth_range": 30
                       },
                       "then_run": {
                         "type": "minecraft:block",
@@ -2420,10 +2282,10 @@
               "type": "minecraft:condition",
               "if_true": {
                 "type": "minecraft:stone_depth",
-                "add_surface_depth": false,
                 "offset": 0,
-                "secondary_depth_range": 0,
-                "surface_type": "floor"
+                "surface_type": "floor",
+                "add_surface_depth": false,
+                "secondary_depth_range": 0
               },
               "then_run": {
                 "type": "minecraft:sequence",
@@ -2461,10 +2323,10 @@
                           "type": "minecraft:condition",
                           "if_true": {
                             "type": "minecraft:stone_depth",
-                            "add_surface_depth": false,
                             "offset": 0,
-                            "secondary_depth_range": 0,
-                            "surface_type": "ceiling"
+                            "surface_type": "ceiling",
+                            "add_surface_depth": false,
+                            "secondary_depth_range": 0
                           },
                           "then_run": {
                             "type": "minecraft:block",
@@ -2489,10 +2351,10 @@
                         "type": "minecraft:condition",
                         "if_true": {
                           "type": "minecraft:stone_depth",
-                          "add_surface_depth": false,
                           "offset": 0,
-                          "secondary_depth_range": 0,
-                          "surface_type": "ceiling"
+                          "surface_type": "ceiling",
+                          "add_surface_depth": false,
+                          "secondary_depth_range": 0
                         },
                         "then_run": {
                           "type": "minecraft:block",
@@ -2519,12 +2381,12 @@
         "type": "minecraft:condition",
         "if_true": {
           "type": "minecraft:vertical_gradient",
-          "false_at_and_above": {
-            "absolute": 8
-          },
           "random_name": "minecraft:blue_terracotta",
           "true_at_and_below": {
             "absolute": 0
+          },
+          "false_at_and_above": {
+            "absolute": 8
           }
         },
         "then_run": {


### PR DESCRIPTION
This PR adds the data pack the user `Sky's Crowned` worked on from Discord, but never made a PR request for. As a discord user they don't have any other identification e.g. a linked git account. But, I'm very grateful that they uploaded this data pack that has fixed an issue for new comers.

I've tested it work known crazy world seeds such as `0`, and it made a huge impact in making the crash space ship structures closer together. Originally you would spawn approx. 200 blocks up in the air next to betty, whilst the other two structures were on the ground. On `0`, this now makes it so they are no more than a few blocks in height from one another
