### PR TITLE
Fix ptdye:recycle_excluded tag

### DIFF
--- a/kubejs/server_scripts/base/features/devices.js
+++ b/kubejs/server_scripts/base/features/devices.js
@@ -561,7 +561,7 @@ if (true) {
         true
       ); //let players transmute any device but don't show in craftables panel
 
-      if(device.recycleExcluded) addToTag("ptdye:recycle_excluded")
+      if(device.recycleExcluded) addToTag("ptdye:recycle_excluded", item.id);
       addToTag(device.tag + tagSuffix, item.id);
       addStonecutting(included_device, device.generic);
     });


### PR DESCRIPTION
This pull request will be merged when its done, when the following checkboxes are checked and when it passes review.

# basic checks
- [x] feature works in singleplayer
- [ ] feature works in multiplayer (verify no de-sync issues)
- [x] feature works in existing world
# feature specific checks
- [ ] test case 1
- [ ] test case 2

Seems like this was a typo or something, but now `bulkrecycle all` will properly refuse to recycle wrenches. Haven't tested in multiplayer but can't imagine that would be an issue.